### PR TITLE
Changed listchars (:set list) highlight color so it looks more distin…

### DIFF
--- a/colors/monochrome.vim
+++ b/colors/monochrome.vim
@@ -91,7 +91,7 @@ call s:hi('Folded')
 call s:hi('LineNr', s:dgray)
 
 " Small arrow used for tabs.
-call s:hi('SpecialKey', s:sblue, s:black, s:bold)
+call s:hi('SpecialKey', s:sblue, s:default_bg, s:bold)
 
 " File browsers.
 call s:hi('Directory', s:white, s:default_bg, s:bold)

--- a/colors/monochrome.vim
+++ b/colors/monochrome.vim
@@ -91,7 +91,7 @@ call s:hi('Folded')
 call s:hi('LineNr', s:dgray)
 
 " Small arrow used for tabs.
-call s:hi('SpecialKey', s:default_fg, s:default_bg, s:bold)
+call s:hi('SpecialKey', s:sblue, s:black, s:bold)
 
 " File browsers.
 call s:hi('Directory', s:white, s:default_bg, s:bold)


### PR DESCRIPTION
Changed listchars (:set list) highlight color so it looks more distinct from regular text and is thus easier to read.

I tried dark grey, red, yellow, green, and blue. Dark grey had the worst contrast out of all of them. Blue, on the other hand, looks reasonably "greyish", and is easy to pick apart from the regular white text. I feel that this is within the spirit of the color scheme, as this isn't for syntax highlighting; it's for distinguishing regular text from whitespace, control characters, et al.