### PR TITLE
Fix default_bg check on guibg/ctermbg if condition

### DIFF
--- a/colors/monochrome.vim
+++ b/colors/monochrome.vim
@@ -53,7 +53,7 @@ function! s:hi(...)
         call add(cmd, 'ctermfg='.fg[1])
     endif
 
-    if bg != s:default_lst && bg != default_bg
+    if bg != s:default_lst && bg != s:default_bg
         call add(cmd, 'guibg='.bg[0])
         call add(cmd, 'ctermbg='.bg[1])
     endif


### PR DESCRIPTION
This fixes the issue of pull request #11 that would lead to "E121: Undefined variable: default_bg" errors on vim startup. Sorry!