### PR TITLE
Inverted MatchParen colors

### DIFF
--- a/colors/monochrome.vim
+++ b/colors/monochrome.vim
@@ -124,7 +124,7 @@ call s:hi('Type', s:white, s:default_bg, s:bold)
 call s:hi('Function', s:white)
 call s:hi('Identifier')
 call s:hi('Special')
-call s:hi('MatchParen', s:black, s:lgray)
+call s:hi('MatchParen', s:lgray, s:black, s:underline)
 
 
 "


### PR DESCRIPTION
This has been driving me crazy ever since I first got this colorscheme: when you go over a bracket, it highlights the opposite bracket, but the cursor's current position turns invisible, which is extremely confusing. See that white cursor? That's not where the cursor actually is.

![image](https://user-images.githubusercontent.com/6936507/130823554-f87a4c7d-d965-4b8f-afcf-7eb1fc522bd4.png)


Inverting it makes the current cursor position visible as normal while letting the match mostly blend into the background. I added an underline to it to make it slightly more visible. Bold doesn't seem to work.

sblue seems to work well, too. The only question is the weird brown-yellow color that is its inverse.

Which do you think looks better? I could go either way.

This PR:
![image](https://user-images.githubusercontent.com/6936507/130823190-36c7b15f-734c-4508-9a96-5f0f4cc98173.png)

Possible alternative:
![image](https://user-images.githubusercontent.com/6936507/130823261-a3f8a1ff-6f94-435a-82c0-6290240c8737.png)
