### PR TITLE
Adds color highlight for ruby symbols

### DIFF
--- a/colors/monochrome.vim
+++ b/colors/monochrome.vim
@@ -150,6 +150,7 @@ hi link vimCommentTitle Comment
 
 call s:hi('rubyConstant')
 call s:hi('rubySharpBang', s:cgray)
+call s:hi('rubySymbol', s:sblue)
 call s:hi('rubyStringDelimiter', s:sblue)
 call s:hi('rubyStringEscape', s:sblue)
 call s:hi('rubyRegexpEscape', s:sblue)


### PR DESCRIPTION
Hey! Thank you for amazing color theme. I'd be happy to see ruby symbols highlighted :hugs: 

## Before
![image](https://user-images.githubusercontent.com/907304/152011649-46cc4305-91d8-4b34-966f-1cbfbcd8db5d.png)

## After
![image](https://user-images.githubusercontent.com/907304/152011690-150573df-c7c8-49aa-a8ee-afcc1e81727a.png)